### PR TITLE
ヒープソートの改善

### DIFF
--- a/lib/sort.f90
+++ b/lib/sort.f90
@@ -115,7 +115,14 @@ module sort_m
         
         if(child2ID <= size(self%node)) then 
             !第2子が存在する（配列サイズ内）場合
-            featuredChildID = get_smallerID(self%node(:)%value, child1ID, child2ID)
+            if (self%node(child1ID)%value < self%node(child2ID)%value) then
+                featuredChildID = child1ID
+            else
+                featuredChildID = child2ID
+            end if
+
+            !self%node(:)%valueの臨時配列生成に時間がかかってたぽい
+            ! featuredChildID = get_smallerID(self%node(:)%value, child1ID, child2ID)
 
         else
             !第2子が存在しない（配列サイズ外）場合
@@ -125,18 +132,18 @@ module sort_m
     
     end function
 
-    function get_smallerID(array, ID1, ID2) result(smaller_ID)
-        real,intent(in) :: array(:)
-        integer, intent(in) :: ID1, ID2
-        integer smaller_ID
+    ! function get_smallerID(array, ID1, ID2) result(smaller_ID)
+    !     real,intent(in) :: array(:)
+    !     integer, intent(in) :: ID1, ID2
+    !     integer smaller_ID
 
-        if (array(ID1) < array(ID2)) then
-            smaller_ID = ID1
-        else
-            smaller_ID = ID2
-        end if
+    !     if (array(ID1) < array(ID2)) then
+    !         smaller_ID = ID1
+    !     else
+    !         smaller_ID = ID2
+    !     end if
     
-    end function
+    ! end function
 
     !>ヒープソート
     subroutine heap_sort(array_origin, array_sorted)

--- a/test/sort_test.f90
+++ b/test/sort_test.f90
@@ -5,10 +5,28 @@ program sort_test
     implicit none
     real, parameter :: test1(10) = [-9.0, -1.0, 0.0, 3.0, 5.0, 7.2, 14.4, 99.9, 122.5, 255.0]
     real, parameter :: test2(11) = [-99.0, -9.0, -1.0, 0.0, 3.0, 5.0, 7.2, 14.4, 99.9, 122.5, 255.0]
+    real test3(1000)
 
     call testing(test1)
+
     print '("==============================================================")'
+
     call testing(test2)
+
+    print '("==============================================================")'
+
+    block
+        integer i
+        real rand
+        !配列を乱数で生成
+        test3(1) = 0.
+        do i = 2, size(test3)
+            call random_number(rand)
+            test3(i) = test3(i-1) + rand
+        end do
+    end block
+
+    call testing(test3)
 
     contains
 
@@ -23,12 +41,17 @@ program sort_test
         array = real2content(tmp)
         call heap_sort(array, array_sorted)
 
-        ! if(.not.isEqual(array_sorted(:)%value, array_correct)) error stop
-        if(.not.all(array_sorted(:)%value == array_correct)) error stop
+        ! ひとつでも違う要素があればテスト失敗
+        if(.not.all(array_sorted(:)%value == array_correct)) then
+            do i = 1, size(array_sorted)
+                print '(2(i6, x, f20.16, 4x, "|"))', &
+                    array(i)%originID, array(i)%value, &
+                    array_sorted(i)%originID, array_sorted(i)%value
+            end do
 
-        do i = 1, size(array_sorted)
-            print '(2(i6, x, f20.16, 4x, "|"))', array(i)%originID, array(i)%value, array_sorted(i)%originID, array_sorted(i)%value
-        end do
+            error stop
+
+        end if
 
     end subroutine
     

--- a/test/sort_test.f90
+++ b/test/sort_test.f90
@@ -5,7 +5,7 @@ program sort_test
     implicit none
     real, parameter :: test1(10) = [-9.0, -1.0, 0.0, 3.0, 5.0, 7.2, 14.4, 99.9, 122.5, 255.0]
     real, parameter :: test2(11) = [-99.0, -9.0, -1.0, 0.0, 3.0, 5.0, 7.2, 14.4, 99.9, 122.5, 255.0]
-    real test3(1000)
+    real test3(10000)
 
     call testing(test1)
 


### PR DESCRIPTION
 `get_smallerID`関数に渡す実引数に、`self%node(:)%value`と臨時配列を指定していたが、どうもこれに時間がかかっていたらしい。
修正後は1万個の要素数に対しても1秒ぐらいでソートし終わるようになった。

(あくまで僕の環境での結果なので、各自検証よろ)